### PR TITLE
記事詳細ページを表示する際、@goodを返却するように修正した

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -23,6 +23,7 @@ class ArticlesController < ApplicationController
 
   def show
     @article = Article.find_by(id: params[:id])
+    @good = Good.new
   end
 
   def edit

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -18,6 +18,7 @@ class ArticlesController < ApplicationController
 
   def new
     @article = Article.new
+    @comment = Comment.new
   end
 
   def show

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -12,6 +12,6 @@ class CommentsController < ApplicationController
   private
 
   def create_params
-    params.required(:comment).permit(:text, :article_id)
+    params.permit(:text, :article_id)
   end
 end

--- a/app/helpers/good_helper.rb
+++ b/app/helpers/good_helper.rb
@@ -1,5 +1,6 @@
 module GoodHelper
   def do_thumb_up?(goods)
+    return false unless current_user
     return true if goods.filter { |n| n.user_id == current_user.id }.present?
 
     false

--- a/app/helpers/session_helper.rb
+++ b/app/helpers/session_helper.rb
@@ -1,0 +1,5 @@
+module SessionHelper
+  def sigin_in?
+    redirect_to new_user_session_path unless user_signed_in?
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,4 +3,5 @@ class Comment < ApplicationRecord
   default_scope -> { order(created_at: :desc) }
   validates :article_id, presence: true
   validates :text, presence: true, length: { maximum: 150 }
+  validates :text, presence: true, length: { maximum: 150 }
 end

--- a/app/views/articles/_good.html.erb
+++ b/app/views/articles/_good.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: current_user.goods.build, remote: true) do |f| %>
+<%= form_with(model: @good, remote: true) do |f| %>
   <div><%= hidden_field_tag :article_id, article.id %></div>
   <%= f.button :type => "submit", class: "good-btn" do %>
     <i class="far fa-thumbs-up fa-fw"></i>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,14 +1,25 @@
 <h1>詳細ページ</h1>
 
-<p>タイトル</p>
-<p><%= @article.title %></p>
+<div class="card card-article">
+  <div class="card-header card-article-header">
+    <p>No <%= @article.id%> <%= @article.title%></p>
+  </div>
+  <div class="card-body">
+    <p class="card-text"><%= @article.content%></p>
+    <%= render 'articles/good_form', {article: @article} %>
+  </div>
+  <% if user_signed_in? %>
+    <button class="btn">
+      <%=link_to "削除", article_path(@article.id), method: :delete %>
+    </button>
+  <% end %>
+</div>
 
-<p>コンテンツ</p>
-<p><%= @article.content %></p>
-
-
-<% if user_signed_in? %> 
-  <button class="btn">
-    <%=link_to "削除", article_path(@article.id), method: :delete %>
-  </button>
+<%= form_with(model: @comment, url: comments_path,) do |f|%>
+  <div class="form-group">
+    <label for="comment_post_form">コメント投稿</label>
+    <%= f.text_area :text, class:"form-control", size: "1x5"%>
+  </div>
+  <%= f.hidden_field :article_id, value: @article.id %>
+  <%= f.submit '送信', class:"btn btn-primary"%>
 <% end %>

--- a/db/migrate/20200810124436_change_datatype_text_of_comment.rb
+++ b/db/migrate/20200810124436_change_datatype_text_of_comment.rb
@@ -1,5 +1,5 @@
 class ChangeDatatypeTextOfComment < ActiveRecord::Migration[6.0]
   def change
-    change_column :comments, :text, :string
+    change_column :comments, :text, :string, {null: false}
   end
 end

--- a/db/migrate/20200812122207_add_user_id_to_comment.rb
+++ b/db/migrate/20200812122207_add_user_id_to_comment.rb
@@ -1,0 +1,6 @@
+class AddUserIdToComment < ActiveRecord::Migration[6.0]
+  def change
+    add_column :comments, :user_id, :integer, {null: false, default: 1}
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_10_124436) do
+ActiveRecord::Schema.define(version: 2020_08_12_122207) do
 
   create_table "articles", force: :cascade do |t|
     t.string "title", default: "", null: false
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2020_08_10_124436) do
     t.integer "article_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "user_id", default: 1, null: false
     t.index ["article_id"], name: "index_comments_on_article_id"
   end
 

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -8,10 +8,8 @@ RSpec.describe CommentsController, type: :request do
 
     let :params do
       {
-        comment: {
           text: text,
           article_id: article_id
-        }
       }
     end
 

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe CommentsController, type: :request do
 
     let :params do
       {
-          text: text,
-          article_id: article_id
+        text: text,
+        article_id: article_id
       }
     end
 


### PR DESCRIPTION
## 内容
記事詳細ページを表示する際、current_user.goodという形でいいね数を表示していたが、未ログイン状態だとエラーになってしまうため、@goodを返却するように修正した。

## 関連issue
なし