### PR TITLE
コメント投稿時にuser.idを渡す

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,7 +8,7 @@ class CommentsController < ApplicationController
 
     @comments.build(comment_params).save
 
-    render 'articles/show'
+    redirect_to request.referer || root_path
   end
 
   def destroy

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -44,7 +44,7 @@
                   <%= render 'comments/goods/good_form', comment: comment %>
                   <% if user_signed_in? &&  comment.owner?(current_user.id) %>
                     <div class="float-right delete-section">
-                      <%= form_with(model: comment, remote: true, method: :delete) do |f| %>
+                      <%= form_with(model: comment, local: true, method: :delete) do |f| %>
                         <%= f.button :type => "submit", class: "trash-button" do %>
                           <i class="fas fa-trash"></i>
                         <% end %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -67,7 +67,7 @@
             <%= f.text_area :text, class:"form-control", size: "1x5"%>
           </div>
           <%= f.hidden_field :article_id, value: @article.id %>
-          <%= f.hidden_field :user_id, value: @article.user_id %>
+          <%= f.hidden_field :user_id, value: current_user&.id %>
           <%= f.submit '送信', class:"btn btn-primary"%>
         <% end %>
       </div>


### PR DESCRIPTION
## 内容
コメント投稿時にarticle.idをコントローラに渡していたため、コメント投稿ユーザのものとは異なるuser_idが登録されてしまった。そのためuser.idを渡すように修正した。