### PR TITLE
factories/articleから非必須項目を削除し、テストがパスするように対応

### DIFF
--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,10 +1,7 @@
 FactoryBot.define do
   factory :article1, class: Article do
     id { 1 }
-    title { 'test' }
-    content { 'test' }
-    user_id { 1 }
-    updated_at { '2020-07-27 22:52:09' }
-    created_at { '2020-07-27 22:52:09' }
+    title { 'title_test' }
+    content { 'content_test' }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Article, type: :model do
+  let :user1 do
+    build(:user1)
+  end
+
+  it '記事を作成できること' do
+    article1 = build(:article1, user: user1)
+    expect(article1).to be_valid
+  end
+
+  context '不正な値の場合' do
+    where(:scenario, :title, :content, :user) do
+      [
+        ['titleが空の場合', '', 'test_content', user1],
+        ['titleがnilの場合', nil, 'test_content', user1],
+        ['titleが50文字より多い場合', 'a' * 51, 'test_content', user1],
+        ['contentが空の場合', 'test_title', '', user1],
+        ['contentがnilの場合', 'test_title', nil, user1],
+        ['contentが150文字より多い場合', 'test_title', 'a' * 151, user1],
+        ['userがnilの場合', 'test_title', 'test_content', nil]
+      ]
+    end
+
+    with_them do
+      context :scenario do
+        it '記事が作成されないこと' do
+          article = build(:article1, title: title, content: content, user: user)
+          expect(article).not_to be_valid
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/article_goods_spec.rb
+++ b/spec/requests/article_goods_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ArticleGoodsController, type: :request do
     end
 
     let :article1 do
-      create(:article1)
+      create(:article1, user: user1)
     end
 
     context 'ログインしている場合' do
@@ -40,7 +40,7 @@ RSpec.describe ArticleGoodsController, type: :request do
 
       context '記事が存在する場合' do
         let :article1 do
-          create(:article1)
+          create(:article1, user: user1)
         end
 
         it 'いいねできていること' do

--- a/spec/requests/comment_goods_spec.rb
+++ b/spec/requests/comment_goods_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CommentGoodsController, type: :request do
     end
 
     let :article1 do
-      create(:article1)
+      create(:article1, user: user1)
     end
 
     let :comment1 do
@@ -103,8 +103,12 @@ RSpec.describe CommentGoodsController, type: :request do
       1
     end
 
+    let :user1 do
+      create(:user1)
+    end
+
     let :article1 do
-      create(:article1)
+      create(:article1, user: user1)
     end
 
     let :comment1 do
@@ -117,7 +121,7 @@ RSpec.describe CommentGoodsController, type: :request do
 
     context 'いいねが存在する場合' do
       before :each do
-        sign_in create(:user1)
+        sign_in user1
         article1
         comment1
         good1

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CommentsController, type: :request do
     context 'ログインしている場合' do
       before :each do
         sign_in user1
-        create(:article1)
+        create(:article1, user: user1)
       end
 
       after :each do
@@ -49,8 +49,7 @@ RSpec.describe CommentsController, type: :request do
 
     context 'ログインしていない場合' do
       before :each do
-        user1
-        create(:article1)
+        create(:article1, user: user1)
       end
 
       it 'コメントが投稿できていること' do
@@ -96,7 +95,7 @@ RSpec.describe CommentsController, type: :request do
     context 'ログインしている場合' do
       before :each do
         sign_in user1
-        create(:article1)
+        create(:article1, user: user1)
         create(:comment1)
       end
 
@@ -136,7 +135,7 @@ RSpec.describe CommentsController, type: :request do
     context 'ログインしていない場合' do
       before :each do
         user1
-        create(:article1)
+        create(:article1, user: user1)
         create(:comment1)
       end
 


### PR DESCRIPTION
## 内容
- factories/articleから非必須項目を削除し、テストがパスするように対応
  -  factories/articleのuserに関してはfactories以下でcreateすると一意制約からrequests/以下でletを定義することができず`sign_in user`といった記述ができなくなるので、specでcreateするようにした。
## 関連issue
#56 